### PR TITLE
Change blenderseed doc link

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -25,7 +25,7 @@ We are actively working on additional tutorials. Thanks for your patience.
 
 ### appleseed Apps, Plugins and Tools
 
-- [appleseed for Blender](https://appleseed-blenderseed.readthedocs.io/en/latest/)
+- [appleseed for Blender](https://appleseed-blenderseed.readthedocs.io)
 - [appleseed for Maya](https://appleseed-maya.readthedocs.io/en/latest/)
 - [appleseed.studio](/docs/appleseed.studio.html)
 - [makefluffy](/docs/makefluffy.html)


### PR DESCRIPTION
The purpose of this is to have the blenderseed docs be linked to the current 'official' release instead of the current master branch.