### PR TITLE
Document studio's shortcuts for context menus

### DIFF
--- a/_docs/appleseed.studio.md
+++ b/_docs/appleseed.studio.md
@@ -54,6 +54,8 @@ Keys | Action
 <kbd>Shift+LMB+drag</kbd> | Move render in viewport
 <kbd>Shift+LMB</kbd> | Focus on viewport
 <kbd>LMB</kbd> | Select entity (based on entity picking mode)
+<kbd>Shift+RMB</kbd> | Open render widget context menu
+<kbd>RMB</kbd> | Open entity context menu
 <kbd>Del</kbd> | Delete selected entity
 
   


### PR DESCRIPTION
| Entity's context menu (`RMB`) | Render Widget's context menu (`Shift+RMB`) |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/13294013/91208872-42256b00-e6e1-11ea-844f-3590ef843d65.png) | ![image](https://user-images.githubusercontent.com/13294013/91208894-4baed300-e6e1-11ea-81cc-c40858cb2934.png) |
